### PR TITLE
chore: add Codey-Bot Jira sync config

### DIFF
--- a/.github/codey-bot.yml
+++ b/.github/codey-bot.yml
@@ -1,0 +1,31 @@
+# Codey-Bot Jira sync configuration.
+# Dry-run mode validates wiring without creating Jira issues.
+dryRun: true
+
+spam:
+  enabled: false
+community:
+  welcomeMessage: null
+  newContributorLabel: null
+  autoLabeler: {}
+pr:
+  requireBody: false
+  conventionalCommits: false
+  autoFormat: false
+qualityGate:
+  enabled: false
+stale:
+  enabled: false
+
+jiraSync:
+  enabled: true
+  projectKey: DEVREL
+  epicKey: DEVREL-2333
+  issueType: Task
+  syncIssues: true
+  syncPullRequests: false
+  labels:
+    - github-sync
+    - sailpoint-oss
+    - saas-connectivity
+    - repo-colab-saas-conn-delimited-file


### PR DESCRIPTION
## Summary
- Adds dry-run Codey-Bot Jira sync configuration for `colab-saas-conn-delimited-file`.
- Routes GitHub issues to `DEVREL-2333` (SaaS Connectivity documentation enhancements) in the DEVREL Jira project.
- Disables non-Jira Codey-Bot features in this repo config unless maintainers opt in later.

## Jira Sync
- Project: `DEVREL`
- Epic: `DEVREL-2333`
- Issue type: `Task`
- Mode: `dryRun: true` for validation only
- Labels: `github-sync`, `sailpoint-oss`, `saas-connectivity`, `repo-colab-saas-conn-delimited-file`

## Rollout Notes
This PR does not create Jira issues while `dryRun` remains true. After maintainers verify Codey-Bot logs and the DEVREL epic destination, a follow-up PR can switch `dryRun` to false.

Generated as part of the public `sailpoint-oss` repo-to-DEVREL Jira wiring rollout.
